### PR TITLE
Add SSH_OPTS support in cluster/ubuntu/config-default.sh  #17934

### DIFF
--- a/cluster/ubuntu/config-default.sh
+++ b/cluster/ubuntu/config-default.sh
@@ -114,3 +114,5 @@ PROXY_SETTING=${PROXY_SETTING:-""}
 
 DEBUG=${DEBUG:-"false"}
 
+# Add SSH_OPTS
+SSH_OPTS="-oPort=22 -oStrictHostKeyChecking=no -oUserKnownHostsFile=/dev/null -oLogLevel=ERROR"


### PR DESCRIPTION
Add SSH_OPTS support in cluster/ubuntu/config-default.sh.This can change ssh and scp default port.

fixes #17934
